### PR TITLE
Bus power control from host computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,7 @@ make dfu
 - 'l', 'L': open in loop back or silent mode
 - 'C': close channel
 - 'V', 'v': hardware and software version
+- 'P', 'p': turn bus power on and off respectively.
+    This is a proprietary extension to the SLCAN protocol.
+    A tool is included to make use of this feature.
 

--- a/src/slcan.c
+++ b/src/slcan.c
@@ -5,6 +5,7 @@
 #include "version.h"
 #include "can_driver.h"
 #include "slcan.h"
+#include "bus_power.h"
 
 #define MAX_FRAME_LEN (sizeof("T1111222281122334455667788EA5F\r")+1)
 
@@ -267,6 +268,16 @@ void slcan_decode_line(char *line)
     // 'Z': // timestamp on/off, Zx[CR]
     // 'm': // acceptance mask, mxxxxxxxx[CR]
     // 'M': // acceptance code, Mxxxxxxxx[CR]
+
+    /* CVRA Proprietary extensions */
+    case 'P': // Enable bus power
+        bus_power(true);
+        slcan_ack(line);
+        break;
+    case 'p': // Disable bus power
+        bus_power(false);
+        slcan_ack(line);
+        break;
     default:
         slcan_nack(line);
         break;

--- a/tests/slcan_test.cpp
+++ b/tests/slcan_test.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include "../src/slcan.h"
 #include "../src/can_driver.h"
+#include "../src/bus_power.h"
 
 
 extern "C" {
@@ -227,6 +228,23 @@ TEST(SlcanTestGroup, SoftwareVersionCommand)
     STRCMP_EQUAL("software version str\r", line);
 }
 
+TEST(SlcanTestGroup, PowerOnBusCommand)
+{
+    mock().expectOneCall("bus_power").withParameter("enable", true);
+    strcpy(line, "P\r");
+    slcan_decode_line(line);
+    STRCMP_EQUAL("\r", line);
+}
+
+TEST(SlcanTestGroup, PowerOffBusCommand)
+{
+    mock().expectOneCall("bus_power").withParameter("enable", false);
+    strcpy(line, "p\r");
+    slcan_decode_line(line);
+    STRCMP_EQUAL("\r", line);
+}
+
+
 int main(int ac, char** av)
 {
     return CommandLineTestRunner::RunAllTests(ac, av);
@@ -291,6 +309,12 @@ char *slcan_getline(void *arg)
 {
     (void) arg;
     return NULL;
+}
+
+bool bus_power(bool enable)
+{
+    mock().actualCall("bus_power").withParameter("enable", enable);
+    return true;
 }
 
 }

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,99 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,12 @@
+# Tools for the CVRA CAN USB dongle
+
+This folder contains tools intended to be used with the CAN USB dongle.
+For now the following are implemented:
+
+* `can_dongle_power`: Controls the state of the CAN bus power.
+    See `--help` for usage.
+
+## Installation
+
+Python 3 is required, the other dependencies will be installed automatically.
+You can install the tools by running `pip install .`.

--- a/tools/cvra_can_usb_dongle/power.py
+++ b/tools/cvra_can_usb_dongle/power.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Turns on or off the CAN bus power.
+"""
+
+import argparse
+import serial
+
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("port", help="Serial port to which the dongle is connected.")
+    parser.add_argument("power", choices=('on', 'off'), help="Bus state to apply")
+
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    conn = serial.Serial(args.port, 115200)
+
+    if args.power == "on":
+        msg = "P\r"
+    else:
+        msg = "p\r"
+
+    conn.write(msg.encode())
+
+    data = bytes()
+
+    while not data.endswith(b"\r"):
+        data += conn.read(1)
+
+if __name__ == '__main__':
+    main()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+
+setup(
+    name='cvra-can-dongle-tools',
+    version='1.0.0',
+    description='Tools for the CVRA CAN USB dongle',
+    author='Club Vaudois de Robotique Autonome',
+    author_email='info@cvra.ch',
+    url='https://github.com/cvra/CAN-USB-dongle-fw',
+    license='BSD',
+    packages=['cvra_can_usb_dongle'],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Embedded Systems',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        ],
+    install_requires=[
+        'pyserial',
+        ],
+    entry_points={
+        'console_scripts': [
+            'can_dongle_power=cvra_can_usb_dongle.power:main',
+            ],
+        },
+    )
+


### PR DESCRIPTION
This PR implements a feature to drive the bus power from the host PC in addition to the onboard button. I needed this feature to automate some build & testing step while working on the UWB beacons. It does not break the existing bus power toggle.